### PR TITLE
feat: implement Todo creation functionality with comprehensive form validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,46 @@ todo-app/
 
 ## Development Workflow
 
-- Run typecheck and lint after completing tasks and be sure they ALWAYS pass.
+### Mandatory Quality Checks
+Before considering any task complete, you MUST run the following commands and ensure they ALL pass:
+
+1. **TypeScript Type Checking**: `npm run typecheck`
+   - Must pass with zero errors
+   - Catches compatibility issues (e.g., Node.js vs Cloudflare Workers APIs)
+   - Validates route types and component interfaces
+
+2. **Unit Tests**: `npm run test`
+   - All tests must pass
+   - Validates component behavior and integration
+   - Ensures no regressions in existing functionality
+
+3. **Build Validation**: `npm run build`
+   - Must complete successfully
+   - Validates production build compatibility
+   - Catches runtime environment issues
+
+### Development Server Testing
+After making changes, always verify:
+- `npm run dev` starts without errors
+- Application loads correctly in browser
+- New functionality works as expected
+- No console errors or warnings
+
+### Critical Environment Considerations
+- **Cloudflare Workers Runtime**: Use Web APIs instead of Node.js APIs
+  - ✅ Use `crypto.randomUUID()` (Web Crypto API)
+  - ❌ Avoid `import { randomUUID } from "crypto"` (Node.js)
+  - ✅ Use `fetch()` for HTTP requests
+  - ❌ Avoid Node.js built-in modules in component code
+
+### Pre-Commit Checklist
+Before committing code, verify:
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes  
+- [ ] `npm run dev` starts without errors
+- [ ] `npm run build` completes successfully
+- [ ] New functionality tested manually
+- [ ] No breaking changes to existing features
 
 ## Database Schema
 
@@ -89,6 +128,7 @@ todo-app/
 CREATE TABLE todos (
   id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
+  notes TEXT,
   completed BOOLEAN DEFAULT FALSE,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -113,10 +153,30 @@ CREATE TABLE todos (
 
 ## Common Issues & Solutions
 
-1. **React Router v7 + Vitest**: Disable router in test environment
-2. **D1 local development**: Use `--local` flag for all D1 commands
-3. **TypeScript errors with D1**: Ensure `@cloudflare/workers-types` is installed
-4. **E2E test failures**: Check if dev server is running on correct port
+1. **Cloudflare Workers Runtime Errors**: 
+   - **Issue**: "Failed to load url crypto" or "Unexpected Node.js imports"
+   - **Solution**: Use Web APIs instead of Node.js modules
+   - **Example**: Use `crypto.randomUUID()` instead of `import { randomUUID } from "crypto"`
+
+2. **React Router v7 + Vitest**: 
+   - **Issue**: Router hooks fail in tests
+   - **Solution**: Wrap components in `MemoryRouter` or mock React Router components
+
+3. **D1 local development**: 
+   - **Issue**: Database operations fail locally
+   - **Solution**: Use `--local` flag for all D1 commands
+
+4. **TypeScript errors with D1**: 
+   - **Issue**: Missing type definitions
+   - **Solution**: Ensure `@cloudflare/workers-types` is installed and run `npm run cf-typegen`
+
+5. **E2E test failures**: 
+   - **Issue**: Tests can't connect to dev server
+   - **Solution**: Check if dev server is running on correct port
+
+6. **Missing Route Types**:
+   - **Issue**: Cannot find module './+types/routename'
+   - **Solution**: Add route to `app/routes.ts` and run `npx react-router typegen`
 
 ## Security Considerations
 

--- a/app/components/AddTaskButton.tsx
+++ b/app/components/AddTaskButton.tsx
@@ -1,8 +1,10 @@
+import { Link } from "react-router";
+
 export function AddTaskButton() {
   return (
-    <button
-      type="button"
-      className="fixed bottom-6 right-6 h-14 w-14 rounded-full bg-[#4e3cdb] text-white shadow-lg hover:bg-[#4334b8] focus:outline-none focus:ring-2 focus:ring-[#4e3cdb] focus:ring-offset-2 transition-colors"
+    <Link
+      to="/new"
+      className="fixed bottom-6 right-6 h-14 w-14 rounded-full bg-[#4e3cdb] text-white shadow-lg hover:bg-[#4334b8] focus:outline-none focus:ring-2 focus:ring-[#4e3cdb] focus:ring-offset-2 transition-colors flex items-center justify-center"
       aria-label="Add new task"
     >
       <svg
@@ -11,7 +13,6 @@ export function AddTaskButton() {
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="mx-auto"
       >
         <path
           d="M12 5V19M5 12H19"
@@ -21,6 +22,6 @@ export function AddTaskButton() {
           strokeLinejoin="round"
         />
       </svg>
-    </button>
+    </Link>
   );
 }

--- a/app/components/TodoCreateForm.tsx
+++ b/app/components/TodoCreateForm.tsx
@@ -1,0 +1,165 @@
+import { Form } from "react-router";
+import { useState } from "react";
+
+interface TodoCreateFormProps {
+  errors?: {
+    title?: string;
+    notes?: string;
+    general?: string;
+  };
+  defaultValues?: {
+    title?: string;
+    notes?: string;
+  };
+}
+
+export function TodoCreateForm({ errors, defaultValues }: TodoCreateFormProps) {
+  const [title, setTitle] = useState(defaultValues?.title || "");
+  const [notes, setNotes] = useState(defaultValues?.notes || "");
+
+  return (
+    <div className="bg-white min-h-screen">
+      {/* Header Navigation Bar */}
+      <div className="bg-white">
+        <div className="flex flex-col">
+          <div className="relative">
+            <div className="flex flex-row items-center justify-center overflow-hidden">
+              <div className="flex flex-row gap-2.5 items-center justify-center px-24 py-3.5 w-full">
+                <div className="font-bold text-black text-[17px] text-center text-nowrap w-[201px]">
+                  <p className="block leading-normal">Create Task</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex flex-col gap-2.5 w-full">
+        <div className="min-h-[812px] w-full">
+          <div className="flex flex-col-reverse min-h-full">
+            {/* Form Fields */}
+            <div className="order-2 w-full">
+              <Form method="post" id="create-todo-form" className="flex flex-col w-full">
+                {/* Error Display */}
+                {errors?.general && (
+                  <div className="mx-4 mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+                    <p className="text-red-600 text-sm">{errors.general}</p>
+                  </div>
+                )}
+
+                {/* Task Name Field */}
+                <div className="bg-white w-full">
+                  <div className="flex flex-col w-full">
+                    {/* Subtitle */}
+                    <div className="w-full">
+                      <div className="flex flex-row items-center">
+                        <div className="flex flex-row gap-2 items-center justify-start px-4 py-1 w-full">
+                          <div className="flex-1 font-normal text-black text-[17px] text-left">
+                            <p className="block leading-[1.35]">Task Name</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    
+                    {/* Text Field */}
+                    <div className="bg-white w-full">
+                      <div className="px-4 py-2 w-full">
+                        <div className="bg-black/5 rounded-[20px] w-full">
+                          <div className="flex flex-row items-center">
+                            <div className="flex flex-row gap-2 items-center justify-start px-[13px] py-[13.5px] w-full">
+                              <input
+                                type="text"
+                                name="title"
+                                id="title"
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                                className="flex-1 bg-transparent border-none outline-none text-[17px] text-black placeholder-black/50"
+                                placeholder="Enter task name"
+                                required
+                                aria-describedby={errors?.title ? "title-error" : undefined}
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        {errors?.title && (
+                          <p id="title-error" className="mt-1 text-sm text-red-600 px-3">
+                            {errors.title}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Notes Field */}
+                <div className="bg-white w-full">
+                  <div className="flex flex-col w-full">
+                    {/* Subtitle */}
+                    <div className="w-full">
+                      <div className="flex flex-row items-center">
+                        <div className="flex flex-row gap-2 items-center justify-start px-4 py-1 w-full">
+                          <div className="flex-1 font-normal text-black text-[17px] text-left">
+                            <p className="block leading-[1.35]">Notes</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    
+                    {/* Text Field */}
+                    <div className="bg-white w-full">
+                      <div className="px-4 py-2 w-full">
+                        <div className="bg-black/5 rounded-[20px] w-full">
+                          <div className="flex flex-row items-center">
+                            <div className="flex flex-row gap-2 items-center justify-start px-[13px] py-[13.5px] w-full">
+                              <textarea
+                                name="notes"
+                                id="notes"
+                                value={notes}
+                                onChange={(e) => setNotes(e.target.value)}
+                                className="flex-1 bg-transparent border-none outline-none text-[17px] text-black placeholder-black/50 resize-none min-h-[1.35rem]"
+                                placeholder="Add notes"
+                                rows={3}
+                                aria-describedby={errors?.notes ? "notes-error" : undefined}
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        {errors?.notes && (
+                          <p id="notes-error" className="mt-1 text-sm text-red-600 px-3">
+                            {errors.notes}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Form>
+            </div>
+
+            {/* Floating Action Button */}
+            <div className="bg-white order-1 w-full">
+              <div className="flex flex-row items-center justify-end">
+                <div className="flex flex-row gap-2 items-center justify-end p-4 w-full">
+                  <button
+                    type="submit"
+                    form="create-todo-form"
+                    className="bg-[#4e3cdb] rounded-[360px] shadow-[0px_2px_6px_0px_rgba(0,0,0,0.08)] hover:bg-[#4334b8] focus:outline-none focus:ring-2 focus:ring-[#4e3cdb] focus:ring-offset-2 transition-colors"
+                  >
+                    <div className="flex flex-row items-center justify-center">
+                      <div className="flex flex-row gap-2 items-center justify-center p-4">
+                        <div className="font-bold text-white text-[17px] text-left text-nowrap">
+                          <p className="block leading-[1.35] whitespace-pre">Add</p>
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/TodoItem.tsx
+++ b/app/components/TodoItem.tsx
@@ -25,9 +25,11 @@ export function TodoItem({ todo }: TodoItemProps) {
         >
           {todo.title}
         </label>
-        <p className="mt-1 text-sm text-[rgba(46,24,20,0.62)] dark:text-gray-400">
-          {todo.description}
-        </p>
+        {todo.notes && (
+          <p className="mt-1 text-sm text-[rgba(46,24,20,0.62)] dark:text-gray-400">
+            {todo.notes}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/app/components/TodoList.tsx
+++ b/app/components/TodoList.tsx
@@ -3,7 +3,7 @@ import { TodoItem } from "./TodoItem";
 export interface Todo {
   id: string;
   title: string;
-  description: string;
+  notes?: string | null;
   completed: boolean;
 }
 

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,0 +1,44 @@
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import * as schema from "../../database/schema";
+import { generateId } from "./utils";
+
+export type Database = DrizzleD1Database<typeof schema>;
+
+export interface CreateTodoData {
+  title: string;
+  notes?: string;
+}
+
+export async function createTodo(db: Database, data: CreateTodoData) {
+  const id = generateId();
+  const now = new Date().toISOString();
+  
+  const [todo] = await db
+    .insert(schema.todos)
+    .values({
+      id,
+      title: data.title,
+      notes: data.notes,
+      completed: false,
+      created_at: now,
+      updated_at: now,
+    })
+    .returning();
+    
+  return todo;
+}
+
+export async function getAllTodos(db: Database) {
+  return db.select().from(schema.todos).orderBy(schema.todos.created_at);
+}
+
+export async function getTodoById(db: Database, id: string) {
+  const [todo] = await db
+    .select()
+    .from(schema.todos)
+    .where(eq(schema.todos.id, id))
+    .limit(1);
+    
+  return todo;
+}

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,7 +1,5 @@
-import { randomUUID } from "crypto";
-
 export function generateId(): string {
-  return randomUUID();
+  return crypto.randomUUID();
 }
 
 export function cn(...classes: (string | undefined | null | false)[]): string {

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,0 +1,9 @@
+import { randomUUID } from "crypto";
+
+export function generateId(): string {
+  return randomUUID();
+}
+
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/app/lib/validations.ts
+++ b/app/lib/validations.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const createTodoSchema = z.object({
+  title: z
+    .string()
+    .min(1, "Task name is required")
+    .max(200, "Task name must be less than 200 characters")
+    .trim(),
+  notes: z
+    .string()
+    .max(500, "Notes must be less than 500 characters")
+    .trim()
+    .optional()
+    .or(z.literal("")),
+});
+
+export type CreateTodoInput = z.infer<typeof createTodoSchema>;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,6 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+  route("new", "routes/new.tsx"),
+] satisfies RouteConfig;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/home";
 import { TodoList } from "../components/TodoList";
 import { AddTaskButton } from "../components/AddTaskButton";
+import { getAllTodos } from "../lib/db";
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -9,15 +10,18 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 
-const todos = [
-  { id: "1", title: "Grocery Shopping", description: "Buy vegetables and fruits", completed: false },
-  { id: "2", title: "Finish Report", description: "Due by EOD", completed: false },
-  { id: "3", title: "Call Plumber", description: "Fix kitchen sink", completed: false },
-  { id: "4", title: "Workout", description: "1 hour of cardio", completed: false },
-  { id: "5", title: "Read Book", description: "Chapter 5 of 'Atomic Habits'", completed: false }
-];
+export async function loader({ context }: Route.LoaderArgs) {
+  try {
+    const todos = await getAllTodos(context.db);
+    return { todos };
+  } catch (error) {
+    console.error("Failed to load todos:", error);
+    // Return empty array as fallback
+    return { todos: [] };
+  }
+}
 
-export default function Home() {
+export default function Home({ loaderData }: Route.ComponentProps) {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-3xl mx-auto p-6">
@@ -27,7 +31,7 @@ export default function Home() {
           </h1>
         </header>
         <main>
-          <TodoList todos={todos} />
+          <TodoList todos={loaderData.todos} />
         </main>
         <AddTaskButton />
       </div>

--- a/app/routes/new.tsx
+++ b/app/routes/new.tsx
@@ -1,0 +1,71 @@
+import type { Route } from "./+types/new";
+import { redirect } from "react-router";
+import { TodoCreateForm } from "../components/TodoCreateForm";
+import { createTodoSchema } from "../lib/validations";
+import { createTodo } from "../lib/db";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Create Task - Todo App" },
+    { name: "description", content: "Create a new todo task" },
+  ];
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const data = {
+    title: formData.get("title"),
+    notes: formData.get("notes"),
+  };
+
+  // Validate the data
+  const result = createTodoSchema.safeParse(data);
+  
+  if (!result.success) {
+    const errors: Record<string, string> = {};
+    result.error.errors.forEach((error) => {
+      if (error.path.length > 0) {
+        errors[error.path[0] as string] = error.message;
+      }
+    });
+    
+    return {
+      errors,
+      defaultValues: {
+        title: typeof data.title === "string" ? data.title : "",
+        notes: typeof data.notes === "string" ? data.notes : "",
+      },
+    };
+  }
+
+  try {
+    // Create the todo
+    await createTodo(context.db, {
+      title: result.data.title,
+      notes: result.data.notes || undefined,
+    });
+
+    // Redirect to home page
+    return redirect("/");
+  } catch (error) {
+    console.error("Failed to create todo:", error);
+    return {
+      errors: {
+        general: "Failed to create task. Please try again.",
+      },
+      defaultValues: {
+        title: result.data.title,
+        notes: result.data.notes || "",
+      },
+    };
+  }
+}
+
+export default function NewTodo({ actionData }: Route.ComponentProps) {
+  return (
+    <TodoCreateForm 
+      errors={actionData?.errors}
+      defaultValues={actionData?.defaultValues}
+    />
+  );
+}

--- a/database/schema.ts
+++ b/database/schema.ts
@@ -3,6 +3,7 @@ import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 export const todos = sqliteTable("todos", {
   id: text().primaryKey(),
   title: text().notNull(),
+  notes: text(),
   completed: integer({ mode: "boolean" }).notNull().default(false),
   created_at: text().notNull().default("CURRENT_TIMESTAMP"),
   updated_at: text().notNull().default("CURRENT_TIMESTAMP"),

--- a/drizzle/0002_add_notes_to_todos.sql
+++ b/drizzle/0002_add_notes_to_todos.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `todos` ADD `notes` text;

--- a/tests/unit/TodoCreateForm.test.tsx
+++ b/tests/unit/TodoCreateForm.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock React Router components for testing
+vi.mock("react-router", () => ({
+  Form: ({ children, ...props }: any) => <form {...props}>{children}</form>,
+}));
+
+import { TodoCreateForm } from "../../app/components/TodoCreateForm";
+
+describe("TodoCreateForm", () => {
+  it("renders form with all fields", () => {
+    render(<TodoCreateForm />);
+    
+    expect(screen.getByText("Create Task")).toBeInTheDocument();
+    expect(screen.getByText("Task Name")).toBeInTheDocument();
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    
+    expect(screen.getByPlaceholderText("Enter task name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Add notes")).toBeInTheDocument();
+    
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("renders with default values", () => {
+    const defaultValues = {
+      title: "Default Title",
+      notes: "Default Notes",
+    };
+    
+    render(<TodoCreateForm defaultValues={defaultValues} />);
+    
+    const titleInput = screen.getByDisplayValue("Default Title");
+    const notesInput = screen.getByDisplayValue("Default Notes");
+    
+    expect(titleInput).toBeInTheDocument();
+    expect(notesInput).toBeInTheDocument();
+  });
+
+  it("renders errors when provided", () => {
+    const errors = {
+      title: "Title is required",
+      notes: "Notes too long",
+      general: "Something went wrong",
+    };
+    
+    render(<TodoCreateForm errors={errors} />);
+    
+    expect(screen.getByText("Title is required")).toBeInTheDocument();
+    expect(screen.getByText("Notes too long")).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("updates form fields when user types", () => {
+    render(<TodoCreateForm />);
+    
+    const titleInput = screen.getByPlaceholderText("Enter task name");
+    const notesInput = screen.getByPlaceholderText("Add notes");
+    
+    fireEvent.change(titleInput, { target: { value: "New Task" } });
+    fireEvent.change(notesInput, { target: { value: "Some notes" } });
+    
+    expect(titleInput).toHaveValue("New Task");
+    expect(notesInput).toHaveValue("Some notes");
+  });
+
+  it("has proper form attributes", () => {
+    const { container } = render(<TodoCreateForm />);
+    
+    const form = container.querySelector("#create-todo-form");
+    expect(form).toHaveAttribute("method", "post");
+    expect(form).toHaveAttribute("id", "create-todo-form");
+    
+    const titleInput = screen.getByPlaceholderText("Enter task name");
+    expect(titleInput).toHaveAttribute("name", "title");
+    expect(titleInput).toHaveAttribute("required");
+    
+    const notesInput = screen.getByPlaceholderText("Add notes");
+    expect(notesInput).toHaveAttribute("name", "notes");
+    expect(notesInput).not.toHaveAttribute("required");
+  });
+
+  it("has proper accessibility attributes", () => {
+    const errors = {
+      title: "Title error",
+      notes: "Notes error",
+    };
+    
+    render(<TodoCreateForm errors={errors} />);
+    
+    const titleInput = screen.getByPlaceholderText("Enter task name");
+    expect(titleInput).toHaveAttribute("aria-describedby", "title-error");
+    
+    const notesInput = screen.getByPlaceholderText("Add notes");
+    expect(notesInput).toHaveAttribute("aria-describedby", "notes-error");
+    
+    expect(screen.getByRole("button", { name: "Add" })).toHaveAttribute("form", "create-todo-form");
+  });
+});

--- a/tests/unit/TodoItem.test.tsx
+++ b/tests/unit/TodoItem.test.tsx
@@ -6,22 +6,22 @@ describe("TodoItem", () => {
   const incompleteTodo = {
     id: "1",
     title: "Test Todo",
-    description: "Test Description",
+    notes: "Test Notes",
     completed: false,
   };
 
   const completedTodo = {
     id: "2",
     title: "Completed Todo",
-    description: "Completed Description",
+    notes: "Completed Notes",
     completed: true,
   };
 
-  it("renders todo item with title and description", () => {
+  it("renders todo item with title and notes", () => {
     render(<TodoItem todo={incompleteTodo} />);
     
     expect(screen.getByText("Test Todo")).toBeInTheDocument();
-    expect(screen.getByText("Test Description")).toBeInTheDocument();
+    expect(screen.getByText("Test Notes")).toBeInTheDocument();
   });
 
   it("renders checkbox with correct state for incomplete todo", () => {
@@ -52,5 +52,18 @@ describe("TodoItem", () => {
     const label = screen.getByText("Test Todo");
     expect(label.tagName).toBe("LABEL");
     expect(label).toHaveAttribute("for", "todo-1");
+  });
+
+  it("does not render notes when not provided", () => {
+    const todoWithoutNotes = {
+      id: "3",
+      title: "Todo without notes",
+      completed: false,
+    };
+    
+    render(<TodoItem todo={todoWithoutNotes} />);
+    
+    expect(screen.getByText("Todo without notes")).toBeInTheDocument();
+    expect(screen.queryByText("Test Notes")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/TodoList.test.tsx
+++ b/tests/unit/TodoList.test.tsx
@@ -4,8 +4,8 @@ import { TodoList } from "../../app/components/TodoList";
 
 describe("TodoList", () => {
   const mockTodos = [
-    { id: "1", title: "Test Todo 1", description: "Description 1", completed: false },
-    { id: "2", title: "Test Todo 2", description: "Description 2", completed: true },
+    { id: "1", title: "Test Todo 1", notes: "Notes 1", completed: false },
+    { id: "2", title: "Test Todo 2", notes: "Notes 2", completed: true },
   ];
 
   it("renders a list of todos", () => {
@@ -19,9 +19,9 @@ describe("TodoList", () => {
     render(<TodoList todos={mockTodos} />);
     
     expect(screen.getByText("Test Todo 1")).toBeInTheDocument();
-    expect(screen.getByText("Description 1")).toBeInTheDocument();
+    expect(screen.getByText("Notes 1")).toBeInTheDocument();
     expect(screen.getByText("Test Todo 2")).toBeInTheDocument();
-    expect(screen.getByText("Description 2")).toBeInTheDocument();
+    expect(screen.getByText("Notes 2")).toBeInTheDocument();
   });
 
   it("renders empty list when no todos", () => {
@@ -51,7 +51,7 @@ describe("TodoList", () => {
   });
 
   it("renders correct number of separators for multiple todos", () => {
-    const threeTodos = [...mockTodos, { id: "3", title: "Test Todo 3", description: "Description 3", completed: false }];
+    const threeTodos = [...mockTodos, { id: "3", title: "Test Todo 3", notes: "Notes 3", completed: false }];
     const { container } = render(<TodoList todos={threeTodos} />);
     
     const separators = container.querySelectorAll("hr");

--- a/tests/unit/home.test.tsx
+++ b/tests/unit/home.test.tsx
@@ -1,46 +1,61 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router";
 import Home from "../../app/routes/home";
 
 describe("Home Route", () => {
+  const mockLoaderData = {
+    todos: [
+      { id: "1", title: "Test Todo 1", notes: "Test Notes 1", completed: false },
+      { id: "2", title: "Test Todo 2", notes: "Test Notes 2", completed: true },
+    ],
+  };
+
+  const renderWithRouter = (loaderData = mockLoaderData) => {
+    return render(
+      <MemoryRouter>
+        <Home loaderData={loaderData} />
+      </MemoryRouter>
+    );
+  };
+
   it("renders the Todo App header", () => {
-    render(<Home />);
+    renderWithRouter();
     
     const header = screen.getByRole("heading", { name: "Todo App", level: 1 });
     expect(header).toBeInTheDocument();
   });
 
-  it("renders all hardcoded todos", () => {
-    render(<Home />);
+  it("renders todos from loader data", () => {
+    renderWithRouter();
     
-    expect(screen.getByText("Grocery Shopping")).toBeInTheDocument();
-    expect(screen.getByText("Buy vegetables and fruits")).toBeInTheDocument();
+    expect(screen.getByText("Test Todo 1")).toBeInTheDocument();
+    expect(screen.getByText("Test Notes 1")).toBeInTheDocument();
     
-    expect(screen.getByText("Finish Report")).toBeInTheDocument();
-    expect(screen.getByText("Due by EOD")).toBeInTheDocument();
-    
-    expect(screen.getByText("Call Plumber")).toBeInTheDocument();
-    expect(screen.getByText("Fix kitchen sink")).toBeInTheDocument();
-    
-    expect(screen.getByText("Workout")).toBeInTheDocument();
-    expect(screen.getByText("1 hour of cardio")).toBeInTheDocument();
-    
-    expect(screen.getByText("Read Book")).toBeInTheDocument();
-    expect(screen.getByText("Chapter 5 of 'Atomic Habits'")).toBeInTheDocument();
+    expect(screen.getByText("Test Todo 2")).toBeInTheDocument();
+    expect(screen.getByText("Test Notes 2")).toBeInTheDocument();
   });
 
-  it("renders the AddTaskButton", () => {
-    render(<Home />);
+  it("renders the AddTaskButton as a link", () => {
+    renderWithRouter();
     
-    const addButton = screen.getByRole("button", { name: "Add new task" });
+    const addButton = screen.getByRole("link", { name: "Add new task" });
     expect(addButton).toBeInTheDocument();
+    expect(addButton).toHaveAttribute("href", "/new");
   });
 
   it("has proper page structure", () => {
-    render(<Home />);
+    renderWithRouter();
     
     expect(screen.getByRole("banner")).toBeInTheDocument();
     expect(screen.getByRole("main")).toBeInTheDocument();
     expect(screen.getByRole("list", { name: "Todo list" })).toBeInTheDocument();
+  });
+
+  it("renders empty list when no todos", () => {
+    renderWithRouter({ todos: [] });
+    
+    expect(screen.getByRole("list", { name: "Todo list" })).toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
新しいTodoアイテムを作成する機能を実装しました。ユーザーはタスク名と注記を入力してTodoを追加できるようになります。

### 実装内容
- 新しいTodo作成フォームページ (`/new`)
- タスク名と注記フィールドを含むレスポンシブなフォームUI
- Zodを使用したフォームバリデーション
- データベーススキーマの更新（notesフィールドの追加）
- Cloudflare Workers環境での動作保証（Web Crypto API使用）
- 包括的なユニットテスト
- エラーハンドリングとユーザーフレンドリーなフィードバック

### 技術的変更
- `AddTaskButton`をリンクボタンに変更
- `TodoCreateForm`コンポーネントの新規作成
- データベース操作用のヘルパー関数追加
- バリデーションスキーマの実装
- 開発ワークフローガイドラインの強化

### テスト
- 新しいコンポーネントのユニットテスト追加
- 既存テストの更新（notes フィールド対応）
- 全てのテストが成功することを確認

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>