### PR TITLE
feat: add Playwright e2e tests for critical user paths

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,6 +48,10 @@ RUN ARCH=$(dpkg --print-architecture) && \
   sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
   rm "git-delta_0.18.2_${ARCH}.deb"
 
+# Add playwright dependencies
+RUN npx playwright install-deps chromium
+ENV PLAYWRIGHT_HTML_HOST=0.0.0.0
+
 # Set up non-root user
 USER node
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /reviews/*
 !reviews/.gitkeep
 
+# playwright
+/playwright-report/
+/test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.0.12",
+        "@playwright/test": "^1.53.0",
         "@react-router/dev": "^7.5.3",
         "@tailwindcss/vite": "^4.1.4",
         "@testing-library/jest-dom": "^6.6.3",
@@ -2294,6 +2295,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-router/dev": {
@@ -5349,6 +5366,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "typecheck": "npm run cf-typegen && react-router typegen && tsc -b",
     "test": "vitest",
     "test:watch": "vitest watch",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:all": "npm run test && npm run test:e2e"
   },
   "dependencies": {
     "drizzle-orm": "~0.36.3",
@@ -26,6 +29,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.0.12",
+    "@playwright/test": "^1.53.0",
     "@react-router/dev": "^7.5.3",
     "@tailwindcss/vite": "^4.1.4",
     "@testing-library/jest-dom": "^6.6.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,71 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://127.0.0.1:5173',
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // Disabled for container environment
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/tests/e2e/todo-app.spec.ts
+++ b/tests/e2e/todo-app.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Todo App Critical Paths', () => {
+  test('should display the home page correctly', async ({ page }) => {
+    await page.goto('/')
+    
+    // Check page title and header
+    await expect(page).toHaveTitle('Todo App')
+    await expect(page.getByRole('heading', { name: 'Todo App' })).toBeVisible()
+    
+    // Check that the todo list is present (even if empty)
+    await expect(page.getByRole('list', { name: 'Todo list' })).toBeVisible()
+    
+    // Check that the Add Task button is present (uses aria-label)
+    await expect(page.getByRole('link', { name: 'Add new task' })).toBeVisible()
+  })
+
+  test('should navigate to create new todo page', async ({ page }) => {
+    await page.goto('/')
+    
+    // Click the Add Task button (uses aria-label)
+    await page.getByRole('link', { name: 'Add new task' }).click()
+    
+    // Should navigate to /new page
+    await expect(page).toHaveURL('/new')
+    await expect(page).toHaveTitle('Create Task - Todo App')
+    
+    // Check form elements are present (using placeholders and names)
+    await expect(page.locator('input[name="title"]')).toBeVisible()
+    await expect(page.locator('textarea[name="notes"]')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Add' })).toBeVisible()
+  })
+
+  test('should create a new todo successfully', async ({ page }) => {
+    await page.goto('/new')
+    
+    // Fill in the form using name attributes - use unique title
+    const uniqueTitle = `Test Todo Item ${Date.now()}`
+    await page.locator('input[name="title"]').fill(uniqueTitle)
+    await page.locator('textarea[name="notes"]').fill('This is a test note')
+    
+    // Submit the form
+    await page.getByRole('button', { name: 'Add' }).click()
+    
+    // Should redirect to home page
+    await expect(page).toHaveURL('/')
+    
+    // The new todo should be visible in the list
+    await expect(page.getByText(uniqueTitle).first()).toBeVisible()
+    await expect(page.getByText('This is a test note').first()).toBeVisible()
+  })
+
+  test('should show validation errors for empty title', async ({ page }) => {
+    await page.goto('/new')
+    
+    // Try to submit form without title
+    await page.getByRole('button', { name: 'Add' }).click()
+    
+    // Check if we're still on the same page (validation should prevent submission)
+    await expect(page).toHaveURL('/new')
+    
+    // Since HTML5 validation might prevent form submission, let's check if the field is required
+    const titleInput = page.locator('input[name="title"]')
+    await expect(titleInput).toHaveAttribute('required')
+  })
+
+  test('should display todo items with checkboxes', async ({ page }) => {
+    // First create a todo with unique name
+    await page.goto('/new')
+    const uniqueTitle = `Checkbox Test Todo ${Date.now()}`
+    await page.locator('input[name="title"]').fill(uniqueTitle)
+    await page.getByRole('button', { name: 'Add' }).click()
+    
+    // Go back to home
+    await expect(page).toHaveURL('/')
+    
+    // Check that the todo item has a checkbox
+    const todoItem = page.getByText(uniqueTitle).first()
+    await expect(todoItem).toBeVisible()
+    
+    // Find the checkbox for this todo
+    const checkbox = page.locator('input[type="checkbox"]').first()
+    await expect(checkbox).toBeVisible()
+    await expect(checkbox).not.toBeChecked()
+  })
+
+  test('complete todo creation flow', async ({ page }) => {
+    // Start from home page
+    await page.goto('/')
+    
+    // Navigate to create new todo
+    await page.getByRole('link', { name: 'Add new task' }).click()
+    await expect(page).toHaveURL('/new')
+    
+    // Create a todo with both title and notes - use unique title
+    const uniqueTitle = `Complete Flow Test ${Date.now()}`
+    await page.locator('input[name="title"]').fill(uniqueTitle)
+    await page.locator('textarea[name="notes"]').fill('Testing the complete flow')
+    await page.getByRole('button', { name: 'Add' }).click()
+    
+    // Verify redirect and content
+    await expect(page).toHaveURL('/')
+    await expect(page.getByText(uniqueTitle).first()).toBeVisible()
+    await expect(page.getByText('Testing the complete flow').first()).toBeVisible()
+    
+    // Verify we can navigate to create another todo
+    await page.getByRole('link', { name: 'Add new task' }).click()
+    await expect(page).toHaveURL('/new')
+    
+    // Verify form is empty/reset
+    await expect(page.locator('input[name="title"]')).toHaveValue('')
+    await expect(page.locator('textarea[name="notes"]')).toHaveValue('')
+  })
+})


### PR DESCRIPTION
## 概要

TodoアプリのクリティカルなユーザーパスをカバーするPlaywright E2Eテストを追加しました。

## 変更内容

- **Playwright テスト環境の構築**
  - @playwright/test をdevDependencyとして追加
  - playwright.config.ts でテスト設定を構成
  - Chrome のみでテスト実行（コンテナ環境に最適化）

- **包括的なE2Eテストスイート**
  - ホームページの表示確認
  - 新規タスク作成ページへのナビゲーション
  - タスクの作成フロー
  - フォームバリデーション
  - チェックボックス機能
  - 完全なタスク作成フロー

- **開発環境の改善**
  - .devcontainer/Dockerfile にPlaywright依存関係を追加
  - .gitignore にPlaywrightのレポートとテスト結果を追加
  - package.json に新しいテストスクリプトを追加

## テスト範囲

- ✅ ホームページの正常表示
- ✅ 新規タスク作成ページへのナビゲーション
- ✅ タスクの正常作成とリダイレクト
- ✅ フォームバリデーション（必須項目）
- ✅ チェックボックス表示と初期状態
- ✅ エンドツーエンドの作成フロー

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)